### PR TITLE
Ensure badges box checked before deletion

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,7 +41,14 @@ void main() async {
   await Hive.openBox<UserProfile>('profile');
 
   // Always delete any existing "badges" data to avoid stale schema errors:
-  await Hive.deleteBoxFromDisk('badges');
+  try {
+    if (await Hive.boxExists('badges')) {
+      await Hive.deleteBoxFromDisk('badges');
+    }
+  } catch (err, st) {
+    debugPrint('Failed to delete badges box: $err');
+    debugPrint('$st');
+  }
   await Hive.openBox<Badge>('badges');
 
   // ─── 3) Decide if we show onboarding or go straight to "/" ────────────────────


### PR DESCRIPTION
## Summary
- check if the `badges` box exists before deleting it
- guard deletion errors so the app can still start

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684093b5f8b0832fb1b744b192455b2f